### PR TITLE
add Linux instructions

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -21,7 +21,10 @@
 
 <ol>
   <li>Plug in your ESP to a USB port. We will install WLED <span id="verstr">0.12.0</span> to it.</li>
-  <li id="coms">Hit "Install" and select the correct COM port. <a onclick="showSerialHelp()">No device found?</a></li>
+  <li id="coms">Hit "Install" and select the correct COM port. 
+    <a onclick="showSerialHelp()">No device found?</a>  
+    <a onclick="showPermissionHelp()" class="showOnLinux">Failed to open serial port?</a>
+  </li>
   <li>Get WLED installed and connected in less than 3 minutes!</li>
 </ol><br><br>
 

--- a/script.js
+++ b/script.js
@@ -15,6 +15,8 @@ function setManifest() {
 
     document.getElementById('inst').setAttribute('manifest', m);
     document.getElementById('verstr').textContent = opt.text;
+
+    checkOS();
 }
 
 
@@ -52,6 +54,12 @@ function checkSupported() {
     else setManifest();
 }
 
+function checkOS() {
+    if (navigator.userAgent.includes("Linux")) {
+        document.body.classList.add("linux");
+    }
+}
+
 function unsupported() {
     document.getElementById('flasher').innerHTML = `Sorry, your browser is not yet supported!<br>
     Please try on Desktop Chrome or Edge.<br>
@@ -62,11 +70,36 @@ function unsupported() {
 }
 
 function showSerialHelp() {
-    document.getElementById('coms').innerHTML = `Hit "Install" and select the correct COM port.<br><br>
+    document.getElementById('coms').innerHTML = `Hit "Install" and select the correct COM port. <a onclick="showPermissionHelp()" class="showOnLinux">Failed to open serial port?</a><br><br>
+    <span class="showOnLinux">
+    Your USB cable might not support data transfer.<br>
+    To check if your cable supports data, connect the device and run:<br>
+    <code>lsusb</code> &mdash; Look for CP210x/CH341<br><br>
+    Missing drivers might also be the issue.<br>
+    To check whether your kernel includes the right driver, run:<br>
+    <code>zcat /proc/config.gz | grep -E "CP210X|CH341"</code><br>
+    You should see:<br>
+    <code>CONFIG_USB_SERIAL_CP210X=m</code> or <code>=y</code> &mdash; for CP2102 (square chip)<br>
+    <code>CONFIG_USB_SERIAL_CH341=m</code> or <code>=y</code> &mdash; for CH34x (rectangular chip)<br>
+    If not present or set to <code>=n</code>, you may need to recompile your kernel with these options enabled.<br><br>
+    Note: Your device may appear as <code>ttyUSBX</code>.
+    </span>
+    <span class="hideOnLinux">
     You might be missing the drivers for your board.<br>
     Here are drivers for chips commonly used in ESP boards:<br>
     <a href="https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers" target="_blank">CP2102 (square chip)</a><br>
     <a href="https://github.com/nodemcu/nodemcu-devkit/tree/master/Drivers" target="_blank">CH34x (rectangular chip)</a><br><br>
-    Make sure your USB cable supports data transfer.<br><br>
+    Make sure your USB cable supports data transfer.
+    </span>
+    <br><br>
+    `;
+}
+
+function showPermissionHelp() {
+    document.getElementById('coms').innerHTML = `Hit "Install" and select the correct COM port. <a onclick="showSerialHelp()">No device found?</a><br><br>
+    Your browser likely does not have the necessary permissions to access the connected ESP device.<br>
+    To resolve this issue, add your user to the group that owns the device (typically <code>/dev/ttyUSB0)</code>:<br>
+    <code>sudo usermod -aG "$(stat --format='%G' /dev/ttyUSB0)" "$USER"</code><br>
+    After running the command, reboot for the changes to take effect.<br><br>
     `;
 }

--- a/style.css
+++ b/style.css
@@ -136,6 +136,18 @@ li {
     padding: 0;
 }
 
+.showOnLinux {
+    display: none;
+}
+
+body.linux .showOnLinux {
+    display: inline-block;
+}
+
+body.linux .hideOnLinux {
+    display: none;
+}
+
 @media (prefers-color-scheme: dark) {
     ewt-install-dialog {
         /*--mdc-theme-primary: #ffa000; /*buttons*/


### PR DESCRIPTION

This adds installation help for Linux, that only show up when a Linux user agent is detected.

## Testing

These instructions have been tested using an ESP32 (CP2102) on Debian, Arch Linux and Fedora.

The `lsusb` command (used to verify whether the USB cable supports data transfer) has also been tested with and without the drivers.