### PR TITLE
Track the floating esp-web-tools@10 tag

### DIFF
--- a/auto.htm
+++ b/auto.htm
@@ -10,7 +10,7 @@
   <title>Install WLED</title>
   <script
     type="module"
-    src="https://unpkg.com/esp-web-tools@10.1.0/dist/web/install-button.js?module"
+    src="https://unpkg.com/esp-web-tools@10/dist/web/install-button.js?module"
   ></script>
   <script src="enable-threads.js"></script>
 </head>

--- a/auto.htm
+++ b/auto.htm
@@ -10,7 +10,7 @@
   <title>Install WLED</title>
   <script
     type="module"
-    src="https://unpkg.com/esp-web-tools@10/dist/web/install-button.js?module"
+    src="https://unpkg.com/esp-web-tools@10.4.0/dist/web/install-button.js?module"
   ></script>
   <script src="enable-threads.js"></script>
 </head>

--- a/index.htm
+++ b/index.htm
@@ -10,7 +10,7 @@
   <title>Install WLED</title>
   <script
     type="module"
-    src="https://unpkg.com/esp-web-tools@10.1.0/dist/web/install-button.js?module"
+    src="https://unpkg.com/esp-web-tools@10/dist/web/install-button.js?module"
   ></script>
   <script src="enable-threads.js"></script>
 </head>

--- a/index.htm
+++ b/index.htm
@@ -10,7 +10,7 @@
   <title>Install WLED</title>
   <script
     type="module"
-    src="https://unpkg.com/esp-web-tools@10/dist/web/install-button.js?module"
+    src="https://unpkg.com/esp-web-tools@10.4.0/dist/web/install-button.js?module"
   ></script>
   <script src="enable-threads.js"></script>
 </head>


### PR DESCRIPTION
The installer is pinned to `esp-web-tools@10.1.0`. This switches `index.htm` and `auto.htm` to the floating `@10` tag so the installer picks up patch releases within v10 automatically (the current release is 10.4.0).

Most of what you gain is on the Improv Wi-Fi side, in [10.3.0](https://github.com/esphome/esp-web-tools/releases/tag/10.3.0): the network picker keeps scanning while the form is open and merges results (so a network the first scan missed still shows up), each network shows signal strength, RSSI and whether it is secured, the strongest one is preselected, a device that reports the Improv *stopped* state now says so instead of leading the user through a form that cannot succeed, and Firefox is recognized as a supported WebSerial browser. [10.4.0](https://github.com/esphome/esp-web-tools/releases/tag/10.4.0) fixes a scan race and default-selection bug in that same picker.

10.3.0 also updates esptool-js to 0.6.0 and adds the optional `serialType` manifest field for projects shipping separate CDC and UART builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the web installer to use ESP Web Tools 10.4.0, improving installation reliability and ensuring access to the latest stable installation experience.
  * Applied the update consistently across both automatic and interactive installation pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->